### PR TITLE
Resolve macro name conflict

### DIFF
--- a/src/Arpeggiator.cpp
+++ b/src/Arpeggiator.cpp
@@ -216,13 +216,13 @@ void Arpeggiator::step() {
 	// Has the trigger input been fired
 	if (triggerStatus) {
 		triggerPulse.trigger(5e-5);
-		if (debug()) { std::cout << stepX << " Triggered" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Triggered" << std::endl; }
 	}
 	
 	
 	// Update the trigger pulse and determine if it is still high
 	bool triggerHigh = triggerPulse.process(delta);
-	if (debug()) { 
+	if (debugEnabled()) { 
 		if (triggerHigh) {
 			std::cout << stepX << " Trigger is high" << std::endl;
 		}
@@ -231,18 +231,18 @@ void Arpeggiator::step() {
 	
 	// Update lock
 	if (lockStatus) {
-		if (debug()) { std::cout << "Toggling lock: " << locked << std::endl; }
+		if (debugEnabled()) { std::cout << "Toggling lock: " << locked << std::endl; }
 		locked = !locked;
 	}
 	
 	if (newSequence) {
 		newSequence--;
-		if (debug()) { std::cout << stepX << " Countdown newSequence " << newSequence << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Countdown newSequence " << newSequence << std::endl; }
 	}
 
 	if (newCycle) {
 		newCycle--;
-		if (debug()) { std::cout << stepX << " Countdown newCycle " << newCycle << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Countdown newCycle " << newCycle << std::endl; }
 	}
 	
 	// OK so the problem here might be that the clock gate is still high right after the trigger gate fired on the previous step
@@ -250,7 +250,7 @@ void Arpeggiator::step() {
 	// Has the clock input been fired
 	bool isClocked = false;
 	if (clockStatus && !triggerHigh) {
-		if (debug()) { std::cout << stepX << " Clocked" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Clocked" << std::endl; }
 		isClocked = true;
 	}
 	
@@ -258,26 +258,26 @@ void Arpeggiator::step() {
 	if (triggerStatus || buttonStatus) {
 		newSequence = COUNTDOWN;
 		newCycle = COUNTDOWN;		
-		if (debug()) { std::cout << stepX << " Triggered" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Triggered" << std::endl; }
 	}
 	
 	
 	// So this is where the free-running could be triggered
 	if (isClocked && !isRunning) { // Must have a clock and not be already running
 		if (!trigActive) { // If nothing plugged into the TRIG input
-			if (debug()) { std::cout << stepX << " Free running sequence; starting" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " Free running sequence; starting" << std::endl; }
 			freeRunning = true; // We're free-running
 			newSequence = COUNTDOWN;
 			newCycle = LAUNCH;
 		} else {
-			if (debug()) { std::cout << stepX << " Triggered sequence; wait for trigger" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " Triggered sequence; wait for trigger" << std::endl; }
 			freeRunning = false;
 		}
 	}
 	
 	// Detect cable being plugged in when free-running, stop free-running
 	if (freeRunning && trigActive && isRunning) {
-		if (debug()) { std::cout << stepX << " TRIG input re-connected" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " TRIG input re-connected" << std::endl; }
 		freeRunning = false;
 	}	
 	
@@ -289,7 +289,7 @@ void Arpeggiator::step() {
 		
 		// Pulse the EOC gate
 		eocPulse.trigger(5e-3);
-		if (debug()) { std::cout << stepX << " Finished Cycle S: " << seq.stepI <<
+		if (debugEnabled()) { std::cout << stepX << " Finished Cycle S: " << seq.stepI <<
 			" C: " << seq.cycleI <<
 			" sRemain: " << seq.stepsRemaining <<
 			" cRemain: " << seq.cycleRemaining << std::endl;
@@ -308,7 +308,7 @@ void Arpeggiator::step() {
 			
 			// Pulse the EOS gate
 			eosPulse.trigger(5e-3);
-			if (debug()) { std::cout << stepX << " Finished sequence S: " << seq.stepI <<
+			if (debugEnabled()) { std::cout << stepX << " Finished sequence S: " << seq.stepI <<
 				" C: " << seq.cycleI <<
 				" sRemain: " << seq.stepsRemaining <<
 				" cRemain: " << seq.cycleRemaining << 
@@ -317,7 +317,7 @@ void Arpeggiator::step() {
 
 		} else {
 			newCycle = LAUNCH;
-			if (debug()) { std::cout << stepX << " Flagging new cycle" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " Flagging new cycle" << std::endl; }
 		}
 		
 	}
@@ -327,9 +327,9 @@ void Arpeggiator::step() {
 	if (newSequence == LAUNCH) {
 		
 		// At the first step of the sequence
-		if (debug()) { std::cout << stepX << " New Sequence" << std::endl;	}
+		if (debugEnabled()) { std::cout << stepX << " New Sequence" << std::endl;	}
 		if (!locked) {
-			if (debug()) { std::cout << stepX << " Update sequence inputs" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " Update sequence inputs" << std::endl; }
 		}
 		// So this is where we tweak the sequence parameters
 		seq.initSequence(inputStep, inputDist, inputPDir, inputSDir, locked);
@@ -343,7 +343,7 @@ void Arpeggiator::step() {
 	// Starting a new cycle
 	if (newCycle == LAUNCH) {
 		
-		if (debug()) {
+		if (debugEnabled()) {
 			
 			std::cout << stepX << " Defining cycle: nStep: " << seq.nStep << 
 				" nDist: " << seq.nDist << 
@@ -362,7 +362,7 @@ void Arpeggiator::step() {
 		/// Reset the cycle counters
 		seq.setCycle(nValidPitches);
 		
-		if (debug()) { std::cout << stepX << " New cycle" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " New cycle" << std::endl; }
 	
 		// Deal with RND setting, when sDir == 1, force it up or down
 		if (seq.sDir == 1) {
@@ -400,7 +400,7 @@ void Arpeggiator::step() {
 				float dV = semiTone * seq.nDist * seq.currDist;
 				pitches[i] = clamp(inputPitches[target] + dV, -10.0, 10.0);
 		
-				if (debug()) {
+				if (debugEnabled()) {
 					std::cout << stepX << " Pitch: " << i << " stepI: " << seq.stepI <<
 						" dV:" << dV <<
 						" target: " << target <<
@@ -410,7 +410,7 @@ void Arpeggiator::step() {
 			}
 		}
 		
-		if (debug()) {
+		if (debugEnabled()) {
 			std::cout << stepX << " Output pitches: ";
 			for (int i = 0; i < nValidPitches; i++) {
 				 std::cout << " P" << i << " V: " << pitches[i];
@@ -425,7 +425,7 @@ void Arpeggiator::step() {
 	// Only advance from the clock
 	if (isRunning && (isClocked || newCycle == LAUNCH)) {
 
-		if (debug()) { std::cout << stepX << " Advance Cycle S: " << seq.stepI <<
+		if (debugEnabled()) { std::cout << stepX << " Advance Cycle S: " << seq.stepI <<
 			" C: " << seq.cycleI <<
 			" sRemain: " << seq.stepsRemaining <<
 			" cRemain: " << seq.cycleRemaining << std::endl;
@@ -434,7 +434,7 @@ void Arpeggiator::step() {
 		// Finally set the out voltage
 		outVolts = pitches[seq.cycleI];
 		
-		if (debug()) { std::cout << stepX << " Output V = " << outVolts << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " Output V = " << outVolts << std::endl; }
 		
 		// Update counters
 		seq.advanceCycle();

--- a/src/ArpeggiatorMkII.cpp
+++ b/src/ArpeggiatorMkII.cpp
@@ -631,7 +631,7 @@ void Arpeggiator2::step() {
 		}
 	}
 
-	// if (debug()) {
+	// if (debugEnabled()) {
 	// 	for (int p = 0; p < nValidPitches; p++) {
 	// 		std::cout << inputPitches[p] << std::endl;
 	// 	}
@@ -639,13 +639,13 @@ void Arpeggiator2::step() {
 	
 	// Always play something
 	if (nValidPitches == 0) {
-		if (debug()) { std::cout << stepX << " " << id  << " No inputs, assume single 0V pitch" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " No inputs, assume single 0V pitch" << std::endl; }
 		nValidPitches = 1;
 	}
 	
 	// Need to understand why this happens
 	if (inputLen == 0) {
-		if (debug()) { std::cout << stepX << " " << id  << " InputLen == 0, aborting" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " InputLen == 0, aborting" << std::endl; }
 		return; // No inputs, no music
 	}
 	
@@ -657,12 +657,12 @@ void Arpeggiator2::step() {
 	// Has the trigger input been fired
 	if (triggerStatus) {
 		triggerPulse.trigger(5e-5);
-		if (debug()) { std::cout << stepX << " " << id  << " Triggered" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Triggered" << std::endl; }
 	}
 	
 	// Update the trigger pulse and determine if it is still high
 	bool triggerHigh = triggerPulse.process(delta);
-	if (debug()) { 
+	if (debugEnabled()) { 
 		if (triggerHigh) {
 			std::cout << stepX << " " << id  << " Trigger is high" << std::endl;
 		}
@@ -670,18 +670,18 @@ void Arpeggiator2::step() {
 	
 	// Update lock
 	if (lockStatus) {
-		if (debug()) { std::cout << "Toggling lock: " << locked << std::endl; }
+		if (debugEnabled()) { std::cout << "Toggling lock: " << locked << std::endl; }
 		locked = !locked;
 	}
 	
 	if (newSequence) {
 		newSequence--;
-		if (debug()) { std::cout << stepX << " " << id  << " Countdown newSequence: " << newSequence << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Countdown newSequence: " << newSequence << std::endl; }
 	}
 	
 	if (newCycle) {
 		newCycle--;
-		if (debug()) { std::cout << stepX << " " << id  << " Countdown newCycle: " << newCycle << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Countdown newCycle: " << newCycle << std::endl; }
 	}
 	
 	// OK so the problem here might be that the clock gate is still high right after the trigger gate fired on the previous step
@@ -689,13 +689,13 @@ void Arpeggiator2::step() {
 	// Has the clock input been fired
 	bool isClocked = false;
 	if (clockStatus && !triggerHigh) {
-		if (debug()) { std::cout << stepX << " " << id  << " Clocked" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Clocked" << std::endl; }
 		isClocked = true;
 	}
 	
 	// Has the trigger input been fired, either on the input or button
 	if (triggerStatus || buttonStatus) {
-		if (debug()) { std::cout << stepX << " " << id  << " Start countdown " << clockActive <<std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Start countdown " << clockActive <<std::endl; }
 		if (clockActive) {
 			newSequence = COUNTDOWN;
 			newCycle = COUNTDOWN;
@@ -705,19 +705,19 @@ void Arpeggiator2::step() {
 	// So this is where the free-running could be triggered
 	if (isClocked && !isRunning) { // Must have a clock and not be already running
 		if (!trigActive) { // If nothing plugged into the TRIG input
-			if (debug()) { std::cout << stepX << " " << id  << " Free running sequence; starting" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " " << id  << " Free running sequence; starting" << std::endl; }
 			freeRunning = true; // We're free-running
 			newSequence = COUNTDOWN;
 			newCycle = LAUNCH;
 		} else {
-			if (debug()) { std::cout << stepX << " " << id  << " Triggered sequence; wait for trigger" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " " << id  << " Triggered sequence; wait for trigger" << std::endl; }
 			freeRunning = false;
 		}
 	}
 	
 	// Detect cable being plugged in when free-running, stop free-running
 	if (freeRunning && trigActive && isRunning) {
-		if (debug()) { std::cout << stepX << " " << id  << " TRIG input re-connected" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " TRIG input re-connected" << std::endl; }
 		freeRunning = false;
 	}	
 	
@@ -729,7 +729,7 @@ void Arpeggiator2::step() {
 		
 		// Pulse the EOC gate
 		eocPulse.trigger(Core::TRIGGER);
-		if (debug()) { std::cout << stepX << " " << id  << " Finished Cycle" << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Finished Cycle" << std::endl; }
 		
 		// Reached the end of the sequence
 		if (isRunning && currPatt->isPatternFinished()) {
@@ -744,11 +744,11 @@ void Arpeggiator2::step() {
 			
 			// Pulse the EOS gate
 			eosPulse.trigger(Core::TRIGGER);
-			if (debug()) { std::cout << stepX << " " << id  << " Finished Sequence, flag: " << isRunning << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " " << id  << " Finished Sequence, flag: " << isRunning << std::endl; }
 
 		} else {
 			newCycle = LAUNCH;
-			if (debug()) { std::cout << stepX << " " << id  << " Flagging new cycle" << std::endl; }
+			if (debugEnabled()) { std::cout << stepX << " " << id  << " Flagging new cycle" << std::endl; }
 		}
 		
 	}
@@ -777,7 +777,7 @@ void Arpeggiator2::step() {
 			
 		}
 
-		if (debug()) { std::cout << stepX << " " << id  << " Initiatise new Sequence: Pattern: " << currPatt->getName() << 
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Initiatise new Sequence: Pattern: " << currPatt->getName() << 
 			" Length: " << inputLen <<
 			" Locked: " << locked << std::endl; }
 		
@@ -812,7 +812,7 @@ void Arpeggiator2::step() {
 				
 		}
 
-		if (debug()) { std::cout << stepX << " " << id  << " Initiatise new Cycle: " << nPitches << " " << currArp->getName() << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Initiatise new Cycle: " << nPitches << " " << currArp->getName() << std::endl; }
 
 		currArp->initialise(nPitches, freeRunning);
 		
@@ -823,15 +823,15 @@ void Arpeggiator2::step() {
 	// Only advance from the clock
 	if (isRunning && (isClocked || newCycle == LAUNCH)) {
 
-		if (debug()) { std::cout << stepX << " " << id  << " Advance Cycle: " << currArp->getPitch() << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Advance Cycle: " << currArp->getPitch() << std::endl; }
 
-		if (debug()) { std::cout << stepX << " " << id  << " Advance Cycle: " << pitches[currArp->getPitch()] << " " << (float)currPatt->getOffset() << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Advance Cycle: " << pitches[currArp->getPitch()] << " " << (float)currPatt->getOffset() << std::endl; }
 
 				
 		// Finally set the out voltage
 		outVolts = clamp(pitches[currArp->getPitch()] + semiTone * (float)currPatt->getOffset(), -10.0f, 10.0f);
 		
-		if (debug()) { std::cout << stepX << " " << id  << " Output V = " << outVolts << std::endl; }
+		if (debugEnabled()) { std::cout << stepX << " " << id  << " Output V = " << outVolts << std::endl; }
 		
 		// Update counters
 		currArp->advance();

--- a/src/Circle.cpp
+++ b/src/Circle.cpp
@@ -112,7 +112,7 @@ void Circle::step() {
 	bool rotRStatus		= rotRTrigger.process(rotRInput);
 		
 	if (rotLStatus) {
-		if (debug()) { std::cout << stepX << " Rotate left: " << curKeyIndex; }
+		if (debugEnabled()) { std::cout << stepX << " Rotate left: " << curKeyIndex; }
 		if (voltScale == FIFTHS) {
 			if (curKeyIndex == 0) {
 				curKeyIndex = 11;
@@ -126,11 +126,11 @@ void Circle::step() {
 			}
 		}
 		
-		if (debug()) { std::cout << " -> " << curKeyIndex << std::endl;	}
+		if (debugEnabled()) { std::cout << " -> " << curKeyIndex << std::endl;	}
 	} 
 	
 	if (rotRStatus) {
-		if (debug()) { std::cout << stepX << " Rotate right: " << curKeyIndex; }
+		if (debugEnabled()) { std::cout << stepX << " Rotate right: " << curKeyIndex; }
 		if (voltScale == FIFTHS) {
 			if (curKeyIndex == 11) {
 				curKeyIndex = 0;
@@ -143,17 +143,17 @@ void Circle::step() {
 				curKeyIndex = curKeyIndex + 12;
 			}
 		}
-		if (debug()) { std::cout << " -> " << curKeyIndex << std::endl;	}
+		if (debugEnabled()) { std::cout << " -> " << curKeyIndex << std::endl;	}
 	} 
 	
 	if (rotLStatus && rotRStatus) {
-		if (debug()) { std::cout << stepX << " Reset " << curKeyIndex << std::endl;	}
+		if (debugEnabled()) { std::cout << stepX << " Reset " << curKeyIndex << std::endl;	}
 		curKeyIndex = baseKeyIndex;
 	}
 	
 	
 	if (newKeyIndex != baseKeyIndex) {
-		if (debug()) { std::cout << stepX << " New base: " << newKeyIndex << std::endl;}
+		if (debugEnabled()) { std::cout << stepX << " New base: " << newKeyIndex << std::endl;}
 		baseKeyIndex = newKeyIndex;
 		curKeyIndex = newKeyIndex;
 	}

--- a/src/Imperfect.cpp
+++ b/src/Imperfect.cpp
@@ -83,7 +83,7 @@ void Imperfect::step() {
 			lastValidInput = -1;
 	
 			if (haveTrigger) {
-				if (debug()) { std::cout << stepX << " " << i << " has active input and has received trigger" << std::endl; }
+				if (debugEnabled()) { std::cout << stepX << " " << i << " has active input and has received trigger" << std::endl; }
 				generateSignal = true;
 				lastValidInput = i;
 			}
@@ -91,7 +91,7 @@ void Imperfect::step() {
 		} else {
 			// We have an output and previously seen a trigger
 			if (outputActive && lastValidInput > -1) {
-				if (debug()) { std::cout << stepX << " " << i << " has active out and has seen trigger on " << lastValidInput << std::endl; }
+				if (debugEnabled()) { std::cout << stepX << " " << i << " has active out and has seen trigger on " << lastValidInput << std::endl; }
 				generateSignal = true;
 			}
 		}
@@ -101,7 +101,7 @@ void Imperfect::step() {
 			counter[i]++;
 			int target = core.ipow(2,params[DIVISION_PARAM + i].value);
 		
-			if (debug()) { 
+			if (debugEnabled()) { 
 				std::cout << stepX << " Div: " << i << ": Target: " << target << " Cnt: " << counter[lastValidInput] << " Exp: " << counter[lastValidInput] % target << std::endl; 
 			}
 
@@ -120,7 +120,7 @@ void Imperfect::step() {
 				double rndG = clamp(core.gaussrand(), -2.0f, 2.0f);
 				gateTime[i] = clamp(gateLen + gateSpr * rndG, 0.02f, 100.0f);
 
-				if (debug()) { 
+				if (debugEnabled()) { 
 					std::cout << stepX << " Delay: " << i << ": Len: " << dlyLen << " Spr: " << dlySpr << " r: " << rndD << " = " << delayTime[i] << std::endl; 
 					std::cout << stepX << " Gate: " << i << ": Len: " << gateLen << ", Spr: " << gateSpr << " r: " << rndG << " = " << gateTime[i] << std::endl; 
 				}

--- a/src/Imperfect2.cpp
+++ b/src/Imperfect2.cpp
@@ -105,7 +105,7 @@ void Imperfect2::step() {
 			lastValidInput = -1;
 	
 			if (haveTrigger) {
-				if (debug()) { std::cout << stepX << " " << i << " has active input and has received trigger" << std::endl; }
+				if (debugEnabled()) { std::cout << stepX << " " << i << " has active input and has received trigger" << std::endl; }
 				generateSignal = true;
 				lastValidInput = i; // Row i has a valid input
 			}
@@ -113,7 +113,7 @@ void Imperfect2::step() {
 		} else {
 			// We have an output plugged in this row and previously seen a trigger on previous row
 			if (outputActive && lastValidInput > -1) {
-				if (debug()) { std::cout << stepX << " " << i << " has active out and has seen trigger on " << lastValidInput << std::endl; }
+				if (debugEnabled()) { std::cout << stepX << " " << i << " has active out and has seen trigger on " << lastValidInput << std::endl; }
 				generateSignal = true;
 			}
 			
@@ -157,7 +157,7 @@ void Imperfect2::step() {
 			counter[i]++;
 			int target = division[i];
 		
-			if (debug()) { 
+			if (debugEnabled()) { 
 				std::cout << stepX << " Div: " << i << ": Target: " << target << " Cnt: " << counter[lastValidInput] << " Exp: " << counter[lastValidInput] % division[i] << std::endl; 
 			}
 
@@ -174,7 +174,7 @@ void Imperfect2::step() {
 					double rndG = clamp(core.gaussrand(), -2.0f, 2.0f);
 					gateTime[i] = clamp(gateLen + gateSpr * rndG, Core::TRIGGER, 100.0f);
 
-					if (debug()) { 
+					if (debugEnabled()) { 
 						std::cout << stepX << " Delay: " << i << ": Len: " << dlyLen << " Spr: " << dlySpr << " r: " << rndD << " = " << delayTime[i] << std::endl; 
 						std::cout << stepX << " Gate: " << i << ": Len: " << gateLen << ", Spr: " << gateSpr << " r: " << rndG << " = " << gateTime[i] << std::endl; 
 					}

--- a/src/UI.hpp
+++ b/src/UI.hpp
@@ -34,7 +34,7 @@ struct AHModule : Module {
 	
 	bool debugFlag = false;
 	
-	inline bool debug() {
+	inline bool debugEnabled() {
 		return debugFlag;
 	}
 	


### PR DESCRIPTION
Hi, thanks for the cool plugins. I ran into an issue building master against the latest Rack dev sources. debug() conflicts with an upstream macro definition. Changing the name of the method locally resolves it.